### PR TITLE
Prepare for publication on hex.pm

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2013 Mariano Guerra
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/package.exs
+++ b/package.exs
@@ -1,0 +1,28 @@
+defmodule Erldn.Mixfile do
+  use Mix.Project
+
+  def project do
+    [app: :erldn,
+    version: "1.0.0",
+    description: description,
+    package: package,
+    deps: deps]
+  end
+
+  defp deps do
+    []
+  end
+
+  defp description do
+    """
+    An edn parser for the Erlang platform.
+    """
+  end
+
+  defp package do
+    [files: ~w(src README.md LICENSE Makefile rebar),
+    contributors: ["Mariano Guerra"],
+    licenses: ["MIT"],
+    links: %{"GitHub" => "https://github.com/marianoguerra/erldn"}]
+  end
+end


### PR DESCRIPTION
Adds a LICENSE file as well as a package.exs file to make publishing to
hex easy.

I wasn't sure about dependencies, so left that empty.  If you need to add a dependency to it, it will look like this:

https://github.com/okeuday/uuid/blob/master/mix.exs#L14

Also, didn't see a version recorded anywhere so I set that to 1.0.0. I added a LICENSE file to represent the license you mention in the README. 
