### PR TITLE
Negative integers and precision indicators

### DIFF
--- a/src/erldn_lexer.xrl
+++ b/src/erldn_lexer.xrl
@@ -4,8 +4,8 @@ Bool = (true|false)
 Nil  = nil
 
 % numbers
-Number      = [0-9]
-Float       = [0-9]+\.[0-9]+([eE][-+]?[0-9]+)?
+Number      = [+-]?[0-9]
+Float       = [+-]?[0-9]+\.[0-9]+([eE][-+]?[0-9]+)?
 
 % delimiters and operators
 OpenList    = \(
@@ -34,6 +34,8 @@ Rules.
 % numbers
 {Float}                  : make_token(float, TokenLine, TokenChars, fun erlang:list_to_float/1).
 {Number}+                : make_token(integer, TokenLine, TokenChars, fun parse_number/1).
+{Float}M                 : make_token(float, TokenLine, TokenChars, fun list_to_float_without_suffix/1).
+{Number}+N               : make_token(integer, TokenLine, TokenChars, fun parse_number_without_suffix/1).
 
 % delimiters and operators
 {OpenList}               : make_token(open_list, TokenLine, TokenChars).
@@ -88,3 +90,11 @@ build_string(Type, Str, Line, _Len) ->
 
 parse_number(Str) ->
     list_to_integer(Str).
+
+parse_number_without_suffix(Str) -> 
+    Init = lists:droplast(Str),
+    list_to_integer(Init).
+
+list_to_float_without_suffix(Str) -> 
+    Init = lists:droplast(Str),
+    erlang:list_to_float(Init).

--- a/test/erldn_lexer_tests.erl
+++ b/test/erldn_lexer_tests.erl
@@ -7,9 +7,19 @@ check(Str, Expected) ->
 
 integer_test() -> check("1", {integer, 1, 1}).
 integer_big_test() -> check("1234", {integer, 1, 1234}).
+integer_plus_test() -> check("+1234", {integer, 1, 1234}).
+integer_minus_test() -> check("-1234", {integer, 1, -1234}).
+integer_minus_zero_test() -> check("-0", {integer, 1, 0}).
+integer_arbitrary_precision_test() -> check("1234N", {integer, 1, 1234}).
 
 float_test() -> check("1.3", {float, 1, 1.3}).
 float_big_test() -> check("1.234", {float, 1, 1.234}).
+float_plus_test() -> check("+1.234", {float, 1, 1.234}).
+float_minus_test() -> check("-1.234", {float, 1, -1.234}).
+float_exp_test() -> check("1.234E1", {float, 1, 12.34}).
+float_plus_exp_test() -> check("1.234e+2", {float, 1, 123.4}).
+float_neg_exp_test() -> check("-1.234e-1", {float, 1, -0.1234}).
+float_exact_precision_test() -> check("1.234M", {float, 1, 1.234}).
 
 bool_true_test() -> check("true", {boolean, 1, true}).
 bool_false_test() -> check("false", {boolean, 1, false}).


### PR DESCRIPTION
Looks like erldn currently returns a symbol if you give it a negative integer or float, and also doesn't know how to handle the M and N precision indicators in edn. I've added some tests and fixes for these issues.