### PR TITLE
Allow a number to be the first character of a keyword.

### DIFF
--- a/src/erldn_lexer.xrl
+++ b/src/erldn_lexer.xrl
@@ -24,7 +24,7 @@ CharReturn  = \\return
 CharTab     = \\tab
 CharSpace   = \\space
 BackSlash   = \\
-Symbol      = [\.\*\+\!\-\_\?\$%&=<>a-zA-Z][\.\*\+\!\-\_\?\$%&=<>a-zA-Z0-9:#]*
+Symbol      = [\.\*\+\!\-\_\?\$%&=<>a-zA-Z0-9][\.\*\+\!\-\_\?\$%&=<>a-zA-Z0-9:#]*
 
 % string stuff
 String      = "(\\\^.|\\.|[^\"])*"
@@ -91,10 +91,10 @@ build_string(Type, Str, Line, _Len) ->
 parse_number(Str) ->
     list_to_integer(Str).
 
-parse_number_without_suffix(Str) -> 
+parse_number_without_suffix(Str) ->
     Init = lists:droplast(Str),
     list_to_integer(Init).
 
-list_to_float_without_suffix(Str) -> 
+list_to_float_without_suffix(Str) ->
     Init = lists:droplast(Str),
     erlang:list_to_float(Init).

--- a/test/erldn_parser_tests.erl
+++ b/test/erldn_parser_tests.erl
@@ -62,6 +62,7 @@ ns1_symbol_test() -> check("org.marianoguerra/erldn",
 
 simple_keyword_test() -> check(":foo", foo).
 nil_keyword_test() -> check(":nil", {keyword, nil}).
+number_keyword_test() -> check(":300x450", '300x450').
 slash_keyword_test() -> check(":/", '/').
 start_with_slash_keyword_test() -> check(":/foo", '/foo').
 ns_keyword_test() -> check(":ns/foo", 'ns/foo').


### PR DESCRIPTION
Hi, we have a bunch of edn we parse as config. In a few places we have keywords like :300x450. They parse just fine in Clojure but fail under erldn. I made a small change to allow the first letter of a keyword to be a number and added a test. Otherwise there should be no behavior changes.
